### PR TITLE
BLT-124 Add ansible to configure GKE cluster

### DIFF
--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -1,0 +1,75 @@
+---
+- name: Configure kubernetes cluster
+  hosts: localhost
+  vars:
+    # GCP configuration
+    gcp_sa_env: GCP_SERVICE_ACCOUNT_FILE
+    gcp_project_env: GCP_PROJECT
+    cluster_name: stage-schedule
+    cluster_zone: us-central1-b
+    
+    # External secrets (es) variables
+    es_repo_url: "https://charts.external-secrets.io"
+    es_repo_name: external-secrets
+    es_chart_name: external-secrets
+    es_namespace: external-secrets
+    es_release_name: external-secrets
+    es_overwrite_values:
+      - value: installCRDs=true
+   
+   # Application
+    schedule_app_repo: "https://github.com/BlueTeam2/class-schedule-k8s.git"
+    schedule_app_clone_dir: /tmp/helm_class_schedule
+    schedule_app_namespace: schedule-app
+    schedule_app_backend_name: backend
+    schedule_app_frontend_name: frontend
+    schedule_app_backend_overwrite_values:
+      - value: environmentType=stage
+
+
+
+  tasks:
+    - name: Generate kubeconfig to use kubeclt
+      ansible.builtin.shell: 
+        cmd: |
+          gcloud auth activate-service-account --key-file="${{ gcp_sa_env }}" --project "${{ gcp_project_env }}"
+    
+    - name: Generate kubeconfig to use kubeclt
+      ansible.builtin.shell: 
+        cmd: |
+          gcloud container clusters get-credentials "{{ cluster_name }}" --zone "{{ cluster_zone }}" --project "${{ gcp_project_env }}"
+
+
+    - name: Add external-secrets repository
+      kubernetes.core.helm_repository:
+        repo_name: "{{ es_repo_name }}"
+        repo_url: "{{ es_repo_url }}"
+
+    - name: Deploy external-secrets chart
+      kubernetes.core.helm:
+        chart_ref: "{{ es_repo_name }}/{{ es_chart_name }}"
+        create_namespace: true
+        release_namespace: "{{ es_namespace }}"
+        release_name: "{{ es_release_name }}"
+        set_values: "{{ es_overwrite_values }}"
+
+    - name: Git clone stable repo on HEAD
+      ansible.builtin.git:
+        repo: "{{ schedule_app_repo }}"
+        dest: "{{ schedule_app_clone_dir }}"
+
+    - name: Deploy backend
+      kubernetes.core.helm:
+        release_name: "{{ schedule_app_backend_name }}"
+        chart_ref: "{{ schedule_app_clone_dir }}/{{ schedule_app_backend_name }}"
+        release_namespace: "{{ schedule_app_namespace }}"
+        create_namespace: true
+        dependency_update: true
+        set_values: "{{ schedule_app_backend_overwrite_values }}"
+
+    - name: Deploy frontend
+      kubernetes.core.helm:
+        release_name: "{{ schedule_app_frontend_name }}"
+        chart_ref: "{{ schedule_app_clone_dir }}/{{ schedule_app_frontend_name }}"
+        release_namespace: "{{ schedule_app_namespace }}"
+        create_namespace: true


### PR DESCRIPTION
## Describe your changes
Add ansible playbook for configuring GKE cluster.
This includes the following steps:

1. Authenticate service account user in order to generate kubeclt configuration file. 
Unfortunately this cannot be done without using shell commands because [`google.cloud.gcp_container_cluster_info`](https://docs.ansible.com/ansible/latest/collections/google/cloud/gcp_container_cluster_info_module.html#ansible-collections-google-cloud-gcp-container-cluster-info-module) does not return necessary information like `clientKey ` which makes imposable retrieving secrets to use k8s modules.
2. Installing the following Helm charts:  
- External secrets
-  Backend
- Frontend 

## Jira issue number (if not present in the header)

## Checklist before requesting a review.
- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines of the project.
- [x] I have attached this pull request to a specific issue.

## Additional Notes
Add any additional context, explanations, or concerns here.
